### PR TITLE
accumulate multi-character blocks to highlight

### DIFF
--- a/denops/@ddu-filters/matcher_fzf.ts
+++ b/denops/@ddu-filters/matcher_fzf.ts
@@ -43,20 +43,26 @@ export class Filter extends BaseFilter<Params> {
     return Promise.resolve(items.map((v) => {
       if (v.start >= 0) {
         const target = v.item.matcherKey || v.item.word;
-        const offset = v.item.display?.indexOf(target) ?? 0;
-        if (offset === -1) {
-          return v.item;
-        }
-
+        const positions = [...v.positions].sort((a, b) => a - b);
         const highlights: ItemHighlight[] = [];
-        for (const position of v.positions) {
+        let cur = positions.shift();
+
+        do {
+          let len = 1;
+
+          while (positions[0] === cur + len) {
+            positions.shift();
+
+            len++;
+          }
+
           highlights.push({
             name: "matched",
             hl_group: args.filterParams.highlightMatched,
-            col: offset + charposToBytepos(target, position) + 1,
-            width: ENCODER.encode(target[position]).length,
+            col: charposToBytepos(target, cur) + 1,
+            width: len,
           });
-        }
+        } while (cur = positions.shift());
 
         return {
           ...v.item,

--- a/denops/@ddu-filters/matcher_fzf.ts
+++ b/denops/@ddu-filters/matcher_fzf.ts
@@ -45,6 +45,12 @@ export class Filter extends BaseFilter<Params> {
         const target = v.item.matcherKey || v.item.word;
         const positions = [...v.positions].sort((a, b) => a - b);
         const highlights: ItemHighlight[] = [];
+        const offset = v.item.display?.indexOf(target) ?? 0;
+
+        if (offset === -1) {
+          return v.item;
+        }
+
         let cur = positions.shift();
 
         do {
@@ -59,7 +65,7 @@ export class Filter extends BaseFilter<Params> {
           highlights.push({
             name: "matched",
             hl_group: args.filterParams.highlightMatched,
-            col: charposToBytepos(target, cur) + 1,
+            col: offset + charposToBytepos(target, cur) + 1, // character position is 1-based
             width: len,
           });
         } while (cur = positions.shift());


### PR DESCRIPTION
hi @yuki-yano , I think the merge into my fork in https://github.com/yuki-yano/ddu-filter-fzf/pull/5 overwrote most of my change. The current version still has a single for loop which adds one highlight per matched character (slower), instead of sorting `positions` and using nested do and while loops to accumulate one highlight per matched block of characters.

I've reapplied the diff after updating main and a quick test shows it working.