### PR TITLE
fix: overwrite item.data

### DIFF
--- a/denops/@ddu-filters/matcher_fzf.ts
+++ b/denops/@ddu-filters/matcher_fzf.ts
@@ -80,6 +80,7 @@ export class Filter extends BaseFilter<Params> {
           ...v.item,
           highlights,
           data: {
+            ...(v.item.data || {}),
             fzfScore: v.score,
           },
         };


### PR DESCRIPTION
SSIA

before this PR, matcher_fzf overwrite item.data property. 
So the other filter which use data property does not work well.

after this PR, it seems to be fixed.

to check the item, you can use the script bellow.

```vim
set rtp+=~/.cache/dein/nvim/repos/github.com/vim-denops/denops.vim

set rtp+=~/.cache/dein/nvim/repos/github.com/Shougo/ddu.vim
set rtp+=~/.cache/dein/nvim/repos/github.com/kamecha/ddu-source-custom_params

set rtp+=~/workspace/Plugin/ddu-filter-fzf

function s:test_items()
	let items = ddu#get_items(#{
				\ input: 'o',
				\ sources: [
				\   #{
				\     name: 'custom_params',
				\     options: #{
				\       matchers: [
				\         #{
				\           name: 'matcher_fzf',
				\           params: #{
				\             highlightMatched: "String",
				\           }
				\         }
				\       ],
				\       sorters: ['sorter_fzf']
				\     },
				\     params: #{
				\       items: [
				\         #{ word: 'foo', data: #{ test: 'Foo' } },
				\         #{ word: 'hoge', data: #{ test: 'Hoge' } },
				\         #{ word: 'piyo', data: #{ test: 'Piyo', dic: #{ T: 'piyoooo' } } },
				\       ]
				\     }
				\   }
				\ ]
				\})
	for item in items
		" check item 
		echomsg item
	endfor
endfunction

command! TestItems call s:test_items()


```